### PR TITLE
Upgrade IntelliJ version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get install -y bash git wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-2021.1.2.tar.gz \
+    && wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-242.20224.38.tar.gz \
     && cd /opt \
     && tar xzf /tmp/idea.tar.gz \
     && mv /opt/idea* /opt/idea \


### PR DESCRIPTION
An old version of IntelliJ does not work properly with code formatted by newer versions. 

**Example #1:**
IntelliJ 2024.1.4:
```
private @NotNull String name;
```

This action:
```
private @NotNull 
String name;
```

**Example #2:**
IntelliJ 2024.1.4:
```
List.of(1, 2, 3).get(
                value)
        .equals(0);
```

This action:
```
List.of(1, 2, 3).get(
        value)
        .equals(0);
```