### PR TITLE
Add support for IDEA version as parameter

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Cache IDEA
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
           key: ${{ runner.os }}-idea-cache
@@ -27,3 +27,4 @@ jobs:
           path: test/
           push-type: "none"
           fail-on-changes: false
+          mute-formatter-output: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 LABEL authors="notdevcody"
 
 RUN apk update \
-    && apk add --no-cache bash git wget openjdk17 e2fsprogs github-cli
+    && apk add --no-cache bash git wget openjdk21-jre e2fsprogs github-cli
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chown -R root:root /usr/local/bin/entrypoint.sh \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Unused for commits.<br>
 Fail if any files were changed by the formatter.<br>
 **Default:** `true`
 
+### `idea-version`
+
+Version of IntelliJ IDEA to use.<br>
+**Default:** `2025.2.4`
+
 ### `style-settings-file`
 
 A path to IntelliJ IDEA code style settings .xml file.<br>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
-          key: ${{ runner.os }}-idea-cache
+          key: ${{ runner.os }}-idea-2025.2.4-cache
       - uses: notdevcody/intellij-format-action@v3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
-          key: ${{ runner.os }}-idea-cache
+          key: ${{ runner.os }}-idea-2025.2.4-cache
       - uses: notdevcody/intellij-format-action@v3.1
         push-type: "commit"
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
-          key: ${{ runner.os }}-idea-2025.2.4-cache
+          key: ${{ runner.os }}-idea-cache
       - uses: notdevcody/intellij-format-action@v3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
-          key: ${{ runner.os }}-idea-2025.2.4-cache
+          key: ${{ runner.os }}-idea-cache
       - uses: notdevcody/intellij-format-action@v3.1
         push-type: "commit"
 ```

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Cache IDEA
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
           key: ${{ runner.os }}-idea-cache

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The title to use for the commit or pull request.<br>
 **Default:** `IntelliJ Code Format`
 
 ### `push-description`
+
 The description to use for the pull request.<br>
 Unused for commits.<br>
 **Default**: Empty
@@ -136,7 +137,7 @@ Fail if any files were changed by the formatter.<br>
 ### `idea-version`
 
 Version of IntelliJ IDEA to use.<br>
-**Default:** `2025.2.4`
+**Default:** `2025.3`
 
 ### `style-settings-file`
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache IDEA
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
           key: ${{ runner.os }}-idea-cache
-      - uses: notdevcody/intellij-format-action@v3.1
+      - uses: notdevcody/intellij-format-action@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -50,17 +50,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Cache IDEA
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
           key: ${{ runner.os }}-idea-cache
-      - uses: notdevcody/intellij-format-action@v3.1
+      - uses: notdevcody/intellij-format-action@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -93,7 +93,7 @@ jobs:
         with:
           path: /home/runner/work/_temp/_github_workflow/idea-cache
           key: ${{ runner.os }}-idea-cache
-      - uses: notdevcody/intellij-format-action@v3.1
+      - uses: notdevcody/intellij-format-action@latest
         push-type: "commit"
 ```
 
@@ -137,7 +137,7 @@ Fail if any files were changed by the formatter.<br>
 ### `idea-version`
 
 Version of IntelliJ IDEA to use.<br>
-**Default:** `2025.3`
+**Default:** `2025.2.6`
 
 ### `style-settings-file`
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: |
       IDEA version to use
     required: false
-    default: "2025.2.4"
+    default: "2025.3"
   path:
     description: |
       Path to a directory which the formatter is executed recursively from. Must be relative to the workspace.

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,11 @@ name: IntelliJ Code Format
 description: |
   Format your code automatically using the IntelliJ formatter.
 inputs:
+  idea-version:
+    description: |
+      IDEA version to use
+    required: false
+    default: "2025.2.1"
   path:
     description: |
       Path to a directory which the formatter is executed recursively from. Must be relative to the workspace.
@@ -49,6 +54,7 @@ runs:
   using: docker
   image: Dockerfile
   args:
+    - ${{ inputs.idea-version }}
     - ${{ inputs.path }}
     - ${{ inputs.include-glob }}
     - ${{ inputs.push-type }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: |
       IDEA version to use
     required: false
-    default: "2025.3"
+    default: "2025.2.6"
   path:
     description: |
       Path to a directory which the formatter is executed recursively from. Must be relative to the workspace.

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: |
       IDEA version to use
     required: false
-    default: "2025.2.1"
+    default: "2025.2.4"
   path:
     description: |
       Path to a directory which the formatter is executed recursively from. Must be relative to the workspace.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 download_idea() {
-  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/idea-$idea_version.tar.gz
+  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-$idea_version.tar.gz
   mkdir -p "$IDEA_DIR"
   tar xzf /tmp/idea.tar.gz -C "$IDEA_DIR" --strip-components=1
   rm /tmp/idea.tar.gz
@@ -47,7 +47,7 @@ if [[ "$style_settings_file" != "unset" ]]; then
   style_flags="-s $style_settings_file"
 fi
 
-IDEA_DIR=${IDEA_CACHE_DIR:-"/github/workflow/idea-cache"}
+IDEA_DIR="/github/workflow/idea-cache"
 
 check_idea_version
 
@@ -61,7 +61,7 @@ else
   output_redirect=""
 fi
 
-eval IDEA_JDK="/usr/lib/jvm/java-17-openjdk" "$IDEA_DIR/bin/format.sh" -m "$include_pattern" $style_flags -r . $output_redirect
+eval IDEA_JDK="/usr/lib/jvm/java-21-openjdk" "$IDEA_DIR/bin/format.sh" -m "$include_pattern" $style_flags -r . $output_redirect
 
 changed_files=$(git status --short)
 changed_files_count=$(echo "$changed_files" | grep -v -e '^$' | wc -l)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,8 @@ check_idea_version() {
   fi
 }
 
-if [[ $# -ne 8 ]]; then
-  echo "Exactly 8 parameters required: idea-version, path, include-glob, push-type, push-title, push-description, fail-on-changes, style-settings-file, mute-formatter-output"
+if [[ $# -ne 9 ]]; then
+  echo "Exactly 9 parameters required: idea-version, path, include-glob, push-type, push-title, push-description, fail-on-changes, style-settings-file, mute-formatter-output"
   exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 download_idea() {
-  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-$idea_version.tar.gz
+  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/idea-$idea_version.tar.gz
   mkdir -p "$IDEA_DIR"
   tar xzf /tmp/idea.tar.gz -C "$IDEA_DIR" --strip-components=1
   rm /tmp/idea.tar.gz

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 download_idea() {
-  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-2025.1.3.tar.gz
+  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-$idea_version.tar.gz
   mkdir -p "$IDEA_DIR"
   tar xzf /tmp/idea.tar.gz -C "$IDEA_DIR" --strip-components=1
   rm /tmp/idea.tar.gz
@@ -12,7 +12,7 @@ check_idea_version() {
   if [[ -d "$IDEA_DIR/bin" ]]; then
     local output
     output=$(IDEA_JDK="/usr/lib/jvm/java-17-openjdk" "$IDEA_DIR/bin/idea.sh" --version 2>/dev/null || true)
-    if [[ "$output" == *"2025.1.3"* ]]; then
+    if [[ "$output" == *"$idea_version"* ]]; then
       echo "Valid IntelliJ IDEA version found."
       echo "Using cached files at $IDEA_DIR."
     else
@@ -27,18 +27,19 @@ check_idea_version() {
 }
 
 if [[ $# -ne 8 ]]; then
-  echo "Exactly 8 parameters required: path, include-glob, push-type, push-title, push-description, fail-on-changes, style-settings-file, mute-formatter-output"
+  echo "Exactly 8 parameters required: idea-version, path, include-glob, push-type, push-title, push-description, fail-on-changes, style-settings-file, mute-formatter-output"
   exit 1
 fi
 
-base_path=$1
-include_pattern=$2
-push_type=$3
-push_title=$4
-push_description=$5
-fail_on_changes=$6
-style_settings_file=$7
-mute_formatter_output=$8
+idea_version=$1
+base_path=$2
+include_pattern=$3
+push_type=$4
+push_title=$5
+push_description=$6
+fail_on_changes=$7
+style_settings_file=$8
+mute_formatter_output=$9
 
 style_flags="-allowDefaults"
 


### PR DESCRIPTION
IDEA updates often. To reduce maintainer load, I propose to offer IntelliJ IDEA version as optional parameter.

I also modified the id for the cache key, but was a bit unsure about this. Could confuse in the one or other direction. One direction: why the version number in the cache key if the user does not configure it. Other direction: If version is not there and user updates version, the cached version might be wrong.