### PR TITLE
IntelliJ Community Edition is no more starting from 2025.3.x, download URL changed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,10 @@
 set -e
 
 download_idea() {
-  wget --no-verbose -O /tmp/idea.tar.gz https://download.jetbrains.com/idea/ideaIC-$idea_version.tar.gz
+  local prefix="idea"
+  [[ "$(printf '%s\n' "2025.3" "$idea_version" | sort -V | head -1)" != "2025.3" ]] && prefix="ideaIC"
+
+  wget --no-verbose -O /tmp/idea.tar.gz "https://download.jetbrains.com/idea/${prefix}-${idea_version}.tar.gz"
   mkdir -p "$IDEA_DIR"
   tar xzf /tmp/idea.tar.gz -C "$IDEA_DIR" --strip-components=1
   rm /tmp/idea.tar.gz


### PR DESCRIPTION
Hello,
this is a simple fix to support IntelliJ Idea versions before they merged community and ultimate editions (<=2025.2.6) and new version (>=2025.3.x)
The URL slightly changes from `ideaIC-xxx` to `idea-xxx`

This was tested in my repo [MaterialFX](https://github.com/palexdev/MaterialFX) for latest version of idea 2025.3.3